### PR TITLE
Add Markdown to detectable Linguist languages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.md linguist-detectable


### PR DESCRIPTION
As the entire blog is written in Markdown, it should be included in the statistics generated by [GitHub's Linguist](https://github.com/github/linguist).
This PR adds a `.gitattributes` file which makes all `*.md` files Linguist-detectable.

*Following the instructions available [here](https://github.com/github/linguist/blob/master/docs/overrides.md).*